### PR TITLE
Allow nested batch_select queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,7 @@ to the underlying QuerySet_ object:
 * extra_
 * defer_
 * only_
+* batch_select
 
 (Note that distinct(), values() etc are not included as they would have
 side-effects on how the extra query is associated with the original query)

--- a/batch_select/models.py
+++ b/batch_select/models.py
@@ -110,7 +110,7 @@ class Batch(Replay):
     # functions on QuerySet that we can invoke via this batch object
     __replayable__ = ('filter', 'exclude', 'annotate', 
                       'order_by', 'reverse', 'select_related',
-                      'extra', 'defer', 'only')
+                      'extra', 'defer', 'only', 'batch_select')
     
     def __init__(self, m2m_fieldname, **filter):
         super(Batch,self).__init__()
@@ -203,4 +203,4 @@ if getattr(settings, 'TESTING_BATCH_SELECT', False):
         locations = models.ManyToManyField(Location)
         
         objects = BatchManager()
-        
+


### PR DESCRIPTION
This minor modification simply adds `batch_select` to the `__replayable__` methods on the `Batch` class. This allows us to make nested `batch_select` queries, e.g.

``` python
entry_batch = Batch('entry_set').batch_select('tags')
sections = Section.objects.batch_select(entries=entry_batch)
```

This is useful when you need to batch select objects spanning multiple relationships.
